### PR TITLE
Fixed issue for Microsoft 365 Shared Mailboxes.

### DIFF
--- a/auth-oauth2/oauth2.php
+++ b/auth-oauth2/oauth2.php
@@ -637,7 +637,6 @@ class MicrosoftEmailOauth2Provider extends GenericEmailOauth2Provider {
     static $urlOptions = [
         'tenant' => 'common',
         'accessType' => 'offline_access',
-        'prompt' => 'consent',
         ];
 }
 ?>

--- a/storage-s3/plugin.php
+++ b/storage-s3/plugin.php
@@ -12,8 +12,7 @@ return array(
         "aws/aws-sdk-php" => array(
             'version' => "3.*",
             'map' => array(
-                'aws/aws-sdk-php/src/{Api*,Arn*,ClientSideMonitoring*,Credentials*,DefaultsMode*,Endpoint*,Exception*,Handler*,Retry*,S3*,Signature*,*.php}' => 'lib/Aws',
-                'aws/aws-sdk-php/src/data' => 'lib/Aws',
+                'aws/aws-sdk-php/src' => 'lib/Aws',
                 'guzzlehttp/guzzle/src' => 'lib/GuzzleHttp',
                 'guzzlehttp/promises/src' => 'lib/GuzzleHttp/Promise',
                 'guzzlehttp/psr7/src/' => 'lib/GuzzleHttp/Psr7',
@@ -23,6 +22,12 @@ return array(
                 'psr/http-message/src' => 'lib/Psr/Http/Message',
             ),
         ),
+    ),
+    'scripts' =>  array(
+        'pre-autoload-dump' => 'Aws\\Script\\Composer\\Composer::removeUnusedServices',
+    ),
+    'extra' => array(
+        'aws/aws-sdk-php' => 'S3',
     ),
     'plugin' =>         'storage.php:S3StoragePlugin'
 );


### PR DESCRIPTION
This issue has been discussed in the following forum post
https://forum.osticket.com/d/101462-oauth2-shared-mailboxes/34

This push fixes and resolves the issue so that the **resource_owner_email** is set correctly as the **Shared Mailbox** email on the **Remote Mailbox** tab and the **User Mailbox / Global Admin** is set on the **Outgoing (SMTP)** tab.

The logic for this is

- To pickup emails you need to use the email address of the account that emails were sent to, this can either be a **User Mailbox** or a **Shared Mailbox**.
- To send emails a **_Licenced Microsoft 365 User Mailbox_** must be used, so the emails are sent from the User Mailbox account that is used to authenticate the **Shared Mailbox** or the actual **User Mailbox** on the Microsoft 365 OAuth2 challenge.

If using Shared Mailboxes, the User Mailbox account that is used to send emails is often referred to as a **Service Account** or a **Global Admin** account.
This account needs to have permissions to be able to access and send emails on behalf of the Shared Mailbox(es) that you configure on your osTicket configuration.